### PR TITLE
feat: Add progress display and publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,67 @@
+# Development files
+test/
+test-*.js
+samples/
+.github/
+.git/
+.gitignore
+
+# Documentation files (except README)
+*.md
+!README.md
+!CHANGELOG.md
+
+# Config files
+.eslintrc*
+.prettierrc*
+tsconfig.json
+jest.config.js
+
+# IDE files
+.vscode/
+.idea/
+*.sublime-*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage
+coverage/
+.nyc_output/
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.temp
+
+# Build artifacts
+dist/
+build/
+
+# Node modules (should already be ignored by npm)
+node_modules/
+
+# Test data
+test-data/
+test-results/
+*.test.js
+*.spec.js
+
+# CI/CD
+.travis.yml
+.circleci/
+appveyor.yml
+
+# Private/sensitive files
+.env
+.env.*
+private/
+secrets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-06-15
+
+### Added
+- Progress display during test execution
+- `--verbose` flag for detailed progress information with progress bars
+- `--no-progress` flag to disable progress display
+- Real-time test status updates
+- Suite completion statistics
+- Total execution time display
+- ProgressReporter class for managing progress output
+
+### Changed
+- TestRunner now integrates with ProgressReporter
+- Improved console output formatting
+- Better visual feedback during test runs
+
+## [1.0.1] - 2025-06-15
+
+### Added
+- npm package publication support
+- Improved package.json configuration for npm registry
+- .npmignore file for cleaner package distribution
+- Updated README with npm installation instructions
+- Sample Chrome extensions for testing and demonstration
+- CI/CD workflow improvements
+
+### Fixed
+- Fixed regex error in LocalizationTestSuite
+- Fixed CLI permissions issue in postinstall script
+- Fixed test framework to use sample extensions instead of parent directory
+
+### Changed
+- Updated version to 1.0.1
+- Enhanced documentation for npm users
+
 ## [1.0.0] - 2024-06-14
 
 ### Added
@@ -45,5 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimal memory footprint (~50MB)
 - No browser dependencies
 
-[Unreleased]: https://github.com/yourusername/chrome-extension-test-framework/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/yourusername/chrome-extension-test-framework/releases/tag/v1.0.0
+[Unreleased]: https://github.com/ibushimaru/chrome-extension-test-framework/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ibushimaru/chrome-extension-test-framework/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/ibushimaru/chrome-extension-test-framework/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/ibushimaru/chrome-extension-test-framework/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Chrome Extension Test Framework
 
+[![npm version](https://badge.fury.io/js/chrome-extension-test-framework.svg)](https://www.npmjs.com/package/chrome-extension-test-framework)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub issues](https://img.shields.io/github/issues/ibushimaru/chrome-extension-test-framework)](https://github.com/ibushimaru/chrome-extension-test-framework/issues)
+[![GitHub stars](https://img.shields.io/github/stars/ibushimaru/chrome-extension-test-framework)](https://github.com/ibushimaru/chrome-extension-test-framework/stargazers)
+
 汎用的なChrome拡張機能テストフレームワーク - ブラウザ不要で高速な静的解析を実行
 
 ## 特徴
@@ -13,14 +18,25 @@
 
 ## インストール
 
-### ローカルインストール
+### npmからインストール（推奨）
 ```bash
-npm install /path/to/chrome-extension-test-framework
+# ローカルインストール
+npm install chrome-extension-test-framework
+
+# グローバルインストール
+npm install -g chrome-extension-test-framework
+
+# 開発依存としてインストール
+npm install --save-dev chrome-extension-test-framework
 ```
 
-### グローバルインストール
+### GitHubからインストール
 ```bash
-npm install -g /path/to/chrome-extension-test-framework
+# 最新版をインストール
+npm install git+https://github.com/ibushimaru/chrome-extension-test-framework.git
+
+# 特定のバージョンをインストール
+npm install git+https://github.com/ibushimaru/chrome-extension-test-framework.git#v1.0.1
 ```
 
 ## クイックスタート

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -77,6 +77,14 @@ for (let i = 0; i < args.length; i++) {
             options.watch = true;
             break;
             
+        case '--no-progress':
+            options.progress = false;
+            break;
+            
+        case '--verbose':
+            options.verbose = true;
+            break;
+            
         default:
             if (!arg.startsWith('-')) {
                 options.extensionPath = path.resolve(arg);
@@ -101,6 +109,8 @@ Options:
   -s, --suites <suites>   Test suites to run (comma-separated or 'all')
   --parallel              Run tests in parallel
   -w, --watch             Watch mode - re-run tests on file changes
+  --no-progress           Disable progress display
+  --verbose               Show detailed progress information
 
 Test Suites:
   manifest      - Validate manifest.json

--- a/index.js
+++ b/index.js
@@ -133,10 +133,11 @@ class ChromeExtensionTestFramework {
      * テストを実行
      */
     async run() {
-        console.log(`🚀 Chrome Extension Test Framework v${VERSION}`);
-        console.log(`📁 Testing: ${this.config.extensionPath}\n`);
-
         const startTime = Date.now();
+        
+        // プログレス表示の開始
+        const totalTests = this.suites.reduce((sum, suite) => sum + suite.tests.length, 0);
+        this.testRunner.progressReporter.start(this.suites.length, totalTests);
         const results = {
             framework: VERSION,
             timestamp: new Date().toISOString(),
@@ -154,6 +155,9 @@ class ChromeExtensionTestFramework {
             // 結果を集計
             results.summary = this.calculateSummary(results.suites);
             results.duration = Date.now() - startTime;
+
+            // プログレス表示の完了
+            this.testRunner.progressReporter.complete(results.summary);
 
             // レポートを生成
             await this.reporter.generate(results);

--- a/lib/ProgressReporter.js
+++ b/lib/ProgressReporter.js
@@ -1,0 +1,157 @@
+/**
+ * ProgressReporter - テスト実行中のプログレス表示
+ */
+
+class ProgressReporter {
+    constructor(options = {}) {
+        this.totalTests = 0;
+        this.completedTests = 0;
+        this.currentSuite = null;
+        this.showProgress = options.showProgress !== false;
+        this.verbose = options.verbose || false;
+        this.startTime = null;
+        this.suiteProgress = new Map();
+    }
+
+    /**
+     * テストスイートの開始
+     */
+    startSuite(suite, testCount) {
+        this.currentSuite = suite.name;
+        this.suiteProgress.set(suite.name, {
+            total: testCount,
+            completed: 0,
+            passed: 0,
+            failed: 0,
+            skipped: 0
+        });
+
+        if (this.showProgress) {
+            console.log(`\n📋 ${suite.name}`);
+            if (suite.description) {
+                console.log(`   ${suite.description}`);
+            }
+            if (this.verbose) {
+                console.log(`   📊 Tests: 0/${testCount}`);
+            }
+        }
+    }
+
+    /**
+     * テストの開始
+     */
+    startTest(testName) {
+        if (this.showProgress && this.verbose) {
+            process.stdout.write(`   ⏳ ${testName}... `);
+        }
+    }
+
+    /**
+     * テストの完了
+     */
+    completeTest(testName, status, error = null) {
+        this.completedTests++;
+        
+        const suiteProgress = this.suiteProgress.get(this.currentSuite);
+        if (suiteProgress) {
+            suiteProgress.completed++;
+            suiteProgress[status]++;
+        }
+
+        if (this.showProgress) {
+            if (this.verbose) {
+                // 行をクリアして結果を表示
+                if (process.stdout.clearLine && process.stdout.cursorTo) {
+                    process.stdout.clearLine();
+                    process.stdout.cursorTo(0);
+                }
+            }
+
+            const icon = status === 'passed' ? '✅' : status === 'failed' ? '❌' : '⏭️';
+            console.log(`   ${icon} ${testName}`);
+            
+            if (status === 'failed' && error) {
+                console.log(`      ${error.message}`);
+            }
+
+            // プログレスバーを表示（詳細モードの場合）
+            if (this.verbose && suiteProgress) {
+                this.showProgressBar(suiteProgress);
+            }
+        }
+    }
+
+    /**
+     * スイートの完了
+     */
+    completeSuite(suiteName) {
+        const suiteProgress = this.suiteProgress.get(suiteName);
+        if (this.showProgress && suiteProgress) {
+            const percentage = Math.round((suiteProgress.passed / suiteProgress.total) * 100);
+            console.log(`   ✨ Suite completed: ${suiteProgress.passed}/${suiteProgress.total} passed (${percentage}%)`);
+        }
+    }
+
+    /**
+     * プログレスバーを表示
+     */
+    showProgressBar(progress) {
+        const percentage = Math.round((progress.completed / progress.total) * 100);
+        const barLength = 30;
+        const filled = Math.round((barLength * progress.completed) / progress.total);
+        const empty = barLength - filled;
+        
+        const bar = '█'.repeat(filled) + '░'.repeat(empty);
+        const stats = `${progress.completed}/${progress.total} (${percentage}%)`;
+        
+        console.log(`   [${bar}] ${stats}`);
+    }
+
+    /**
+     * 全体の開始
+     */
+    start(totalSuites, totalTests) {
+        this.totalTests = totalTests;
+        this.startTime = Date.now();
+        
+        if (this.showProgress) {
+            const packageInfo = require('../package.json');
+            console.log(`\n🚀 Chrome Extension Test Framework v${packageInfo.version}`);
+            console.log(`📁 Testing: ${process.cwd()}`);
+            if (this.verbose) {
+                console.log(`📊 Total: ${totalSuites} suites, ${totalTests} tests`);
+            }
+        }
+    }
+
+    /**
+     * 全体の完了
+     */
+    complete(summary) {
+        if (this.showProgress) {
+            const duration = Date.now() - this.startTime;
+            const minutes = Math.floor(duration / 60000);
+            const seconds = ((duration % 60000) / 1000).toFixed(1);
+            const timeStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+            
+            console.log(`\n⏱️  Total time: ${timeStr}`);
+            
+            // 簡易サマリー表示
+            if (!this.verbose) {
+                const passRate = Math.round((summary.passed / summary.total) * 100);
+                console.log(`📈 Results: ${summary.passed}/${summary.total} passed (${passRate}%)`);
+            }
+        }
+    }
+
+    /**
+     * リアルタイム更新（CI/CD環境用）
+     */
+    updateProgress(message) {
+        if (this.showProgress && process.env.CI) {
+            console.log(`::group::${message}`);
+        }
+    }
+}
+
+module.exports = ProgressReporter;

--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -4,12 +4,17 @@
 
 const fs = require('fs');
 const path = require('path');
+const ProgressReporter = require('./ProgressReporter');
 
 class TestRunner {
     constructor(config) {
         this.config = config;
         this.results = [];
         this.currentSuite = null;
+        this.progressReporter = new ProgressReporter({
+            showProgress: config.progress !== false,
+            verbose: config.verbose || false
+        });
     }
 
     updateConfig(config) {
@@ -28,10 +33,8 @@ class TestRunner {
             tests: []
         };
 
-        console.log(`\n📋 ${suite.name}`);
-        if (suite.description) {
-            console.log(`   ${suite.description}`);
-        }
+        // プログレスレポーターでスイート開始を通知
+        this.progressReporter.startSuite(suite, suite.tests.length);
 
         // beforeAllフックを実行
         if (suite.beforeAll) {
@@ -60,6 +63,9 @@ class TestRunner {
         suiteResult.endTime = Date.now();
         suiteResult.duration = suiteResult.endTime - suiteResult.startTime;
 
+        // スイート完了を通知
+        this.progressReporter.completeSuite(suite.name);
+
         return suiteResult;
     }
 
@@ -78,9 +84,12 @@ class TestRunner {
         // スキップ判定
         if (testCase.skip || (testCase.condition && !testCase.condition(this.config))) {
             testResult.status = 'skipped';
-            console.log(`   ⏭️  ${testCase.name} (skipped)`);
+            this.progressReporter.completeTest(testCase.name, 'skipped');
             return testResult;
         }
+
+        // テスト開始を通知
+        this.progressReporter.startTest(testCase.name);
 
         try {
             // beforeEachフックを実行
@@ -101,7 +110,7 @@ class TestRunner {
             await Promise.race([testPromise, timeoutPromise]);
 
             testResult.status = 'passed';
-            console.log(`   ✅ ${testCase.name}`);
+            this.progressReporter.completeTest(testCase.name, 'passed');
 
             // afterEachフックを実行
             if (suite.afterEach) {
@@ -114,8 +123,7 @@ class TestRunner {
                 message: error.message,
                 stack: error.stack
             };
-            console.log(`   ❌ ${testCase.name}`);
-            console.log(`      ${error.message}`);
+            this.progressReporter.completeTest(testCase.name, 'failed', error);
         }
 
         testResult.endTime = Date.now();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension-test-framework",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Universal testing framework for Chrome extensions - Fast static analysis without browser dependencies",
   "main": "index.js",
   "bin": {
@@ -42,7 +42,14 @@
     "lib/",
     "suites/",
     "bin/",
+    "scripts/",
     "README.md",
-    "LICENSE"
-  ]
+    "LICENSE",
+    "CHANGELOG.md",
+    "example.config.js"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/suites/LocalizationTestSuite.js
+++ b/suites/LocalizationTestSuite.js
@@ -195,7 +195,7 @@ class LocalizationTestSuite extends TestSuite {
                 // ハードコードされた文字列の検出（簡易的）
                 const stringLiterals = content.match(/['"]([^'"]{10,})['"](?!\s*[,:])/g) || [];
                 const suspiciousStrings = stringLiterals.filter(str => {
-                    const cleaned = str.replace(/['"]g, '');
+                    const cleaned = str.replace(/['"]/g, '');
                     return /[A-Z]/.test(cleaned) && /\s/.test(cleaned); // 大文字とスペースを含む
                 });
                 

--- a/test/framework.test.js
+++ b/test/framework.test.js
@@ -9,8 +9,8 @@ async function testFramework() {
     console.log('🧪 Testing Chrome Extension Test Framework...\n');
     
     try {
-        // 親ディレクトリの拡張機能をテスト
-        const extensionPath = path.join(__dirname, '..', '..');
+        // サンプルの拡張機能をテスト（good-extensionを使用）
+        const extensionPath = path.join(__dirname, '..', 'samples', 'good-extension');
         
         // フレームワークのインスタンスを作成
         const framework = new ChromeExtensionTestFramework({
@@ -35,6 +35,7 @@ async function testFramework() {
         
     } catch (error) {
         console.error('❌ Framework test failed:', error.message);
+        console.error('Stack trace:', error.stack);
         process.exit(1);
     }
 }


### PR DESCRIPTION
## 概要
この PR は以下の改善を含みます：

### 1. プログレス表示機能の追加 ✨
- 新しい `ProgressReporter` クラスを追加
- テスト実行中のリアルタイムプログレス表示
- `--verbose` フラグで詳細な進捗情報を表示
- `--no-progress` フラグでプログレス表示を無効化
- 各スイートの完了統計と総実行時間を表示

### 2. npm パッケージとして公開 📦
- npm レジストリに公開（v1.1.0）
- パッケージ名: `chrome-extension-test-framework`
- README に npm バッジを追加
- インストール方法を更新

### 3. バグ修正 🐛
- LocalizationTestSuite の正規表現エラーを修正
- テストフレームワークが適切なサンプル拡張機能を使用するように修正

## インストール方法
```bash
npm install chrome-extension-test-framework
```

## 使用例
```bash
# 通常の実行
cext-test

# 詳細なプログレス表示
cext-test --verbose

# プログレス表示なし
cext-test --no-progress
```

## 変更内容
- 🆕 `lib/ProgressReporter.js` - プログレス表示の実装
- 📝 `README.md` - npm バッジとインストール方法の追加
- 🔧 `package.json` - バージョン 1.1.0 に更新
- 📜 `CHANGELOG.md` - v1.1.0 の変更内容を記載
- 🚫 `.npmignore` - npm パッケージから除外するファイルを定義
- ✏️ その他のファイルの改善

## npm パッケージ
- URL: https://www.npmjs.com/package/chrome-extension-test-framework
- バージョン: 1.1.0

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed progress display during test execution, including real-time status updates, suite completion stats, and total execution time.
  - Introduced `--verbose` and `--no-progress` command-line options for customizable progress reporting.
- **Bug Fixes**
  - Fixed a regular expression error in string detection for localization testing.
  - Resolved CLI permission and test path issues.
- **Documentation**
  - Updated README with badges and improved installation instructions.
  - Enhanced changelog with new release details and links.
- **Chores**
  - Added a comprehensive `.npmignore` file to optimize npm package contents.
  - Improved package configuration and CI/CD workflow.
- **Tests**
  - Updated test paths and enhanced error reporting for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->